### PR TITLE
feat: add midnight safety reset automation

### DIFF
--- a/custom_components/battery_energy_trading/__init__.py
+++ b/custom_components/battery_energy_trading/__init__.py
@@ -40,6 +40,7 @@ SERVICE_UNINSTALL_AUTOMATIONS = "uninstall_automations"
 AUTOMATION_IDS = [
     "battery_trading_auto_discharge",
     "battery_trading_auto_charging",
+    "battery_trading_midnight_reset",
 ]
 
 

--- a/custom_components/battery_energy_trading/automation_helper.py
+++ b/custom_components/battery_energy_trading/automation_helper.py
@@ -113,6 +113,62 @@ automation:
               option: "Self-consumption"
 """
 
+# Template for midnight safety reset (Modbus control)
+MIDNIGHT_RESET_MODBUS_TEMPLATE = """
+automation:
+  - alias: "Battery Trading: Midnight Safety Reset"
+    description: "Auto-generated: Reset inverter to Self-consumption at midnight if no active slots"
+    id: battery_trading_midnight_reset
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_forced_discharge
+        state: 'off'
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_cheapest_hours
+        state: 'off'
+    action:
+      - service: select.select_option
+        target:
+          entity_id: {ems_mode_entity}
+        data:
+          option: "Self-consumption"
+      - service: number.set_value
+        target:
+          entity_id: {discharge_power_entity}
+        data:
+          value: 0
+      - service: number.set_value
+        target:
+          entity_id: {charge_power_entity}
+        data:
+          value: 0
+"""
+
+# Template for midnight safety reset (script-based control)
+MIDNIGHT_RESET_SCRIPT_TEMPLATE = """
+automation:
+  - alias: "Battery Trading: Midnight Safety Reset"
+    description: "Auto-generated: Reset inverter to Self-consumption at midnight if no active slots"
+    id: battery_trading_midnight_reset
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_forced_discharge
+        state: 'off'
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_cheapest_hours
+        state: 'off'
+    action:
+      - service: {normal_service}
+        target:
+          entity_id: {normal_entity}
+"""
+
 # Template for script-based control (Sungrow scripts or custom)
 DISCHARGE_AUTOMATION_SCRIPT_TEMPLATE = """
 automation:
@@ -249,6 +305,16 @@ class AutomationScriptGenerator:
         entities = self._get_script_entities()
         return CHARGING_AUTOMATION_SCRIPT_TEMPLATE.format(**entities)
 
+    def generate_midnight_reset_automation(self) -> str:
+        """Generate midnight safety reset automation YAML."""
+        if self.control_type == INVERTER_CONTROL_SUNGROW_MODBUS:
+            entities = self._get_modbus_entities()
+            return MIDNIGHT_RESET_MODBUS_TEMPLATE.format(**entities)
+
+        # Script-based control (sungrow_scripts or custom)
+        entities = self._get_script_entities()
+        return MIDNIGHT_RESET_SCRIPT_TEMPLATE.format(**entities)
+
     def get_control_type_description(self) -> str:
         """Get a human-readable description of the control type."""
         if self.control_type == INVERTER_CONTROL_SUNGROW_MODBUS:
@@ -269,4 +335,6 @@ class AutomationScriptGenerator:
 {self.generate_discharge_automation()}
 
 {self.generate_charging_automation()}
+
+{self.generate_midnight_reset_automation()}
 """

--- a/custom_components/battery_energy_trading/automation_installer.py
+++ b/custom_components/battery_energy_trading/automation_installer.py
@@ -32,6 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 # Automation IDs used by this integration
 DISCHARGE_AUTOMATION_ID = "battery_trading_auto_discharge"
 CHARGING_AUTOMATION_ID = "battery_trading_auto_charging"
+MIDNIGHT_RESET_AUTOMATION_ID = "battery_trading_midnight_reset"
 
 
 class AutomationInstaller:
@@ -276,6 +277,66 @@ class AutomationInstaller:
 
         return base_config
 
+    def _get_midnight_reset_automation_config(self) -> dict[str, Any]:
+        """Generate midnight safety reset automation configuration."""
+        base_config: dict[str, Any] = {
+            "id": MIDNIGHT_RESET_AUTOMATION_ID,
+            "alias": "Battery Trading: Midnight Safety Reset",
+            "description": f"Auto-installed by Battery Energy Trading integration (entry: {self.config_entry.entry_id})",
+            "trigger": [
+                {
+                    "platform": "time",
+                    "at": "00:00:00",
+                },
+            ],
+            "condition": [
+                {
+                    "condition": "state",
+                    "entity_id": "binary_sensor.battery_energy_trading_forced_discharge",
+                    "state": "off",
+                },
+                {
+                    "condition": "state",
+                    "entity_id": "binary_sensor.battery_energy_trading_cheapest_hours",
+                    "state": "off",
+                },
+            ],
+            "mode": "single",
+        }
+
+        if self._control_type == INVERTER_CONTROL_SUNGROW_MODBUS:
+            base_config["action"] = [
+                {
+                    "service": "select.select_option",
+                    "target": {"entity_id": DEFAULT_SUNGROW_MODBUS_EMS_MODE},
+                    "data": {"option": "Self-consumption"},
+                },
+                {
+                    "service": "number.set_value",
+                    "target": {"entity_id": DEFAULT_SUNGROW_MODBUS_DISCHARGE_POWER},
+                    "data": {"value": 0},
+                },
+                {
+                    "service": "number.set_value",
+                    "target": {"entity_id": DEFAULT_SUNGROW_MODBUS_CHARGE_POWER},
+                    "data": {"value": 0},
+                },
+            ]
+        else:
+            normal_service = self.config_entry.options.get(
+                CONF_CUSTOM_NORMAL_SERVICE, "script.turn_on"
+            )
+            normal_entity = self.config_entry.options.get(CONF_CUSTOM_NORMAL_ENTITY, "")
+
+            base_config["action"] = [
+                {
+                    "service": normal_service,
+                    "target": {"entity_id": normal_entity},
+                }
+            ]
+
+        return base_config
+
     async def async_install_automations(self) -> list[str]:
         """Install automations programmatically using Home Assistant's automation helpers.
 
@@ -287,6 +348,7 @@ class AutomationInstaller:
         # Get automation configurations
         discharge_config = self._get_discharge_automation_config()
         charging_config = self._get_charging_automation_config()
+        midnight_reset_config = self._get_midnight_reset_automation_config()
 
         # Try to create automations using the automation.create service if available
         # Note: This is the preferred method but requires HA 2023.4+
@@ -320,6 +382,7 @@ class AutomationInstaller:
             self.hass.data[DOMAIN]["pending_automations"] = {
                 "discharge": discharge_config,
                 "charging": charging_config,
+                "midnight_reset": midnight_reset_config,
             }
 
             # Try using the automation.create service (if available in newer HA versions)
@@ -354,6 +417,21 @@ class AutomationInstaller:
             except Exception as err:
                 _LOGGER.debug("Could not create charging automation: %s", err)
 
+            try:
+                # Create midnight safety reset automation
+                await self.hass.services.async_call(
+                    AUTOMATION_DOMAIN,
+                    "create",
+                    midnight_reset_config,
+                    blocking=True,
+                )
+                created_ids.append(MIDNIGHT_RESET_AUTOMATION_ID)
+                _LOGGER.info(
+                    "Created midnight reset automation: %s", MIDNIGHT_RESET_AUTOMATION_ID
+                )
+            except Exception as err:
+                _LOGGER.debug("Could not create midnight reset automation: %s", err)
+
             # If direct creation failed, store configs and fire event with YAML
             if not created_ids:
                 _LOGGER.info(
@@ -381,7 +459,11 @@ class AutomationInstaller:
                 )
 
                 # Return the IDs that would be created
-                created_ids = [DISCHARGE_AUTOMATION_ID, CHARGING_AUTOMATION_ID]
+                created_ids = [
+                    DISCHARGE_AUTOMATION_ID,
+                    CHARGING_AUTOMATION_ID,
+                    MIDNIGHT_RESET_AUTOMATION_ID,
+                ]
 
         except Exception as err:
             _LOGGER.error("Failed to install automations: %s", err)
@@ -401,7 +483,11 @@ class AutomationInstaller:
         entity_registry = er.async_get(self.hass)
 
         # Find and remove automations by their unique IDs
-        for automation_id in [DISCHARGE_AUTOMATION_ID, CHARGING_AUTOMATION_ID]:
+        for automation_id in [
+            DISCHARGE_AUTOMATION_ID,
+            CHARGING_AUTOMATION_ID,
+            MIDNIGHT_RESET_AUTOMATION_ID,
+        ]:
             # Look for entity with matching unique_id
             entity_id = f"automation.{automation_id}"
 
@@ -459,7 +545,11 @@ class AutomationInstaller:
             "missing": [],
         }
 
-        for automation_id in [DISCHARGE_AUTOMATION_ID, CHARGING_AUTOMATION_ID]:
+        for automation_id in [
+            DISCHARGE_AUTOMATION_ID,
+            CHARGING_AUTOMATION_ID,
+            MIDNIGHT_RESET_AUTOMATION_ID,
+        ]:
             entity_id = f"automation.{automation_id}"
             state = self.hass.states.get(entity_id)
 

--- a/custom_components/battery_energy_trading/automation_installer.py
+++ b/custom_components/battery_energy_trading/automation_installer.py
@@ -426,9 +426,7 @@ class AutomationInstaller:
                     blocking=True,
                 )
                 created_ids.append(MIDNIGHT_RESET_AUTOMATION_ID)
-                _LOGGER.info(
-                    "Created midnight reset automation: %s", MIDNIGHT_RESET_AUTOMATION_ID
-                )
+                _LOGGER.info("Created midnight reset automation: %s", MIDNIGHT_RESET_AUTOMATION_ID)
             except Exception as err:
                 _LOGGER.debug("Could not create midnight reset automation: %s", err)
 

--- a/docs/integrations/sungrow.md
+++ b/docs/integrations/sungrow.md
@@ -386,6 +386,44 @@ automation:
           message: "Discharge stopped - Battery below 15%"
 ```
 
+### 6. Midnight Safety Reset
+
+Reset inverter to Self-consumption at midnight to prevent the inverter from getting stuck in Forced Mode overnight (e.g., after a failed state transition or external override):
+
+```yaml
+automation:
+  - alias: "Battery Trading: Midnight Safety Reset"
+    description: "Reset inverter to Self-consumption at midnight if no active slots"
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_forced_discharge
+        state: 'off'
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_cheapest_hours
+        state: 'off'
+    action:
+      - service: select.select_option
+        target:
+          entity_id: select.sungrow_ems_mode
+        data:
+          option: "Self-consumption"
+
+      - service: number.set_value
+        target:
+          entity_id: number.sungrow_forced_discharging_power
+        data:
+          value: 0
+
+      - service: number.set_value
+        target:
+          entity_id: number.sungrow_forced_charging_power
+        data:
+          value: 0
+```
+
 ## 📊 Dashboard Integration
 
 Add Sungrow entities to your Battery Energy Trading dashboard:
@@ -502,6 +540,25 @@ automation:
             {% else %}
               0
             {% endif %}
+
+  # Midnight safety reset - prevents inverter from staying in wrong mode
+  - alias: "Battery Trading: Midnight Safety Reset"
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_forced_discharge
+        state: 'off'
+      - condition: state
+        entity_id: binary_sensor.battery_energy_trading_cheapest_hours
+        state: 'off'
+    action:
+      - service: select.select_option
+        target:
+          entity_id: select.sungrow_ems_mode
+        data:
+          option: "Self-consumption"
 ```
 
 ## 💡 Tips

--- a/docs/legacy_configuration.yaml
+++ b/docs/legacy_configuration.yaml
@@ -1,0 +1,467 @@
+# Home Assistant Configuration - Battery Management & Energy Trading
+# Loads default set of integrations. Do not remove.
+default_config:
+
+# Uncomment and configure SSL if needed
+#http:
+#  ssl_certificate: /ssl/fullchain.pem
+#  ssl_key: /ssl/privkey.pem
+
+# Load frontend themes from the themes folder
+frontend:
+  themes: !include_dir_merge_named themes
+
+# Configuration for battery management and energy trading
+input_number:
+  forced_discharge_hours:
+    name: "Set selling hours"
+    min: 0
+    max: 32
+    step: 1
+    unit_of_measurement: "hours"
+    initial: 8
+    
+  min_export_price:
+    name: "Minimum Export Price"
+    min: -0.3
+    max: 0.1
+    step: 0.0001
+    unit_of_measurement: "EUR"
+    initial: 0.0125
+      
+  min_forced_sell_price:
+    name: "Minimum Forced Sell Price"
+    min: 0
+    max: 0.5
+    step: 0.01
+    unit_of_measurement: "EUR"
+    initial: 0.3
+    
+  max_price_force_charge:
+    name: "Maximum price for force charge"
+    min: -0.5
+    max: 0.20
+    step: 0.005
+    unit_of_measurement: "EUR"
+    initial: 0.00
+  
+  max_battery_f_charging_time:
+    name: "Battery force charging hours"
+    min: 0
+    max: 24
+    step: 1
+    unit_of_measurement: "hours"
+    initial: 1
+    
+  force_charge_battery_target:
+    name: "Force Charge: Battery target %"
+    min: 0
+    max: 100
+    initial: 70
+    unit_of_measurement: "%"
+    
+  min_battery_discharge_level:
+    name: "Minimum Battery Level for Discharge"
+    min: 10
+    max: 50
+    step: 1
+    initial: 25
+    unit_of_measurement: "%"
+    
+  min_solar_power_threshold:
+    name: "Minimum Solar Power for Discharge Override"
+    min: 0
+    max: 5000
+    step: 100
+    initial: 500
+    unit_of_measurement: "W"
+
+# Timers for battery operations
+timer:
+  forced_battery_charging:
+    duration: '00:01:00'
+  forced_discharge:
+    duration: '00:01:00'
+
+# Template sensors and binary sensors - FULL RESTORED VERSION
+template:
+  - sensor:
+      # Arbitrage opportunity detector
+      - name: arbitrage_opportunities
+        unique_id: arbitrage_opportunities
+        state: >-
+          {% set threshold = 100 %}
+          {% set raw_prices = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'raw_today') %}
+          {% if raw_prices and raw_prices|length > 2 %}
+            {% set ns = namespace(best_opportunity={
+              'charge_start_hour': 0,
+              'charge_end_hour': 1,
+              'discharge_hour': 2,
+              'difference': 0
+            }) %}
+            {% for i in range(raw_prices | length - 2) %}
+              {% set charge_price = (raw_prices[i].value + raw_prices[i+1].value) / 2 %}
+              {% for j in range(i+2, raw_prices | length) %}
+                {% set discharge_price = raw_prices[j].value %}
+                {% set price_difference = (discharge_price - charge_price) * 1000 %}
+                {% if price_difference > threshold and price_difference > ns.best_opportunity.difference %}
+                  {% set ns.best_opportunity = {
+                    'charge_start_hour': raw_prices[i].start.hour,
+                    'charge_end_hour': raw_prices[i+1].end.hour,
+                    'discharge_hour': raw_prices[j].start.hour,
+                    'difference': price_difference
+                  } %}
+                {% endif %}
+              {% endfor %}
+            {% endfor %}
+            {% if ns.best_opportunity.difference > 0 %}
+              Charge from hour {{ ns.best_opportunity.charge_start_hour }} to {{ ns.best_opportunity.charge_end_hour }}, Discharge at hour {{ ns.best_opportunity.discharge_hour }} (Difference: {{ ns.best_opportunity.difference|round(0) }} points)
+            {% else %}
+              No profitable arbitrage opportunities found (threshold: {{ threshold }} points)
+            {% endif %}
+          {% else %}
+            No price data available
+          {% endif %}
+
+      # Selected hours for forced discharge
+      - name: selected_hours_for_forced_discharge
+        unique_id: selected_hours_for_forced_discharge
+        state: >-
+          {% set sell_hours = states('input_number.forced_discharge_hours')|int(2) %}
+          {% set min_price = states('input_number.min_forced_sell_price')|float(0.3) %}
+          {% set today_data = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'raw_today') %}
+          {% if today_data %}
+            {% set sorted_data = today_data|sort(attribute='value', reverse=true) %}
+            {% set ns = namespace(selected_hours='', counter=0) %}
+            {% for entry in sorted_data %}
+              {% if entry.value >= min_price and ns.counter < sell_hours %}
+                {% set ns.selected_hours = ns.selected_hours + entry.start.strftime('%Y-%m-%d %H:%M:%S') + ', ' %}
+                {% set ns.counter = ns.counter + 1 %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.selected_hours[:-2] if ns.selected_hours else 'No hours selected' }}
+          {% else %}
+            No data available
+          {% endif %}
+            
+      # Selected hours for forced charging today
+      - name: selected_hours_for_forced_charging_today
+        unique_id: selected_hours_for_forced_charging_today
+        state: >-
+          {% set hours_needed = states('input_number.max_battery_f_charging_time')|int(1) %}
+          {% set max_price = states('input_number.max_price_force_charge')|float(0) %}
+          {% set nordpool_data = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'raw_today') %}
+          {% if nordpool_data %}
+            {% set sorted_data = nordpool_data|sort(attribute='value') %}
+            {% set ns = namespace(selected_hours=[]) %}
+            {% for entry in sorted_data %}
+              {% if entry.value <= max_price and ns.selected_hours|length < hours_needed %}
+                {% set ns.selected_hours = ns.selected_hours + [entry.start.strftime('%Y-%m-%d %H:%M:%S')] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.selected_hours }}
+          {% else %}
+            []
+          {% endif %}
+              
+      # Selected hours for profitable sell
+      - name: selected_hours_for_profitable_sell
+        unique_id: selected_hours_for_profitable_sell
+        state: >-
+          {% set min_sell_price = states('input_number.min_forced_sell_price')|float(0.3) %}
+          {% set sell_hours = states('input_number.forced_discharge_hours')|int(2) %}
+          {% set today_data = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'raw_today') %}
+          {% if today_data %}
+            {% set sorted_data = today_data|sort(attribute='value', reverse=true) %}
+            {% set ns = namespace(profitable_hours=[], counter=0) %}
+            {% for entry in sorted_data %}
+              {% if entry.value >= min_sell_price + 0.1 and ns.counter < sell_hours %}
+                {% set ns.profitable_hours = ns.profitable_hours + [entry.start.strftime('%H:%M')] %}
+                {% set ns.counter = ns.counter + 1 %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.profitable_hours }}
+          {% else %}
+            []
+          {% endif %}
+            
+      # Selected hours for economical charge
+      - name: selected_hours_for_economical_charge
+        unique_id: selected_hours_for_economical_charge
+        state: >-
+          {% set max_price = states('input_number.max_price_force_charge')|float(0) %}
+          {% set hours_needed = states('input_number.max_battery_f_charging_time')|int(1) %}
+          {% set profitable_hours = states('sensor.selected_hours_for_profitable_sell') %}
+          {% set today_data = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'raw_today') %}
+          {% if today_data %}
+            {% set sorted_data = today_data|sort(attribute='value') %}
+            {% set ns = namespace(economical_hours=[], counter=0) %}
+            {% for entry in sorted_data %}
+              {% set hour = entry.start.strftime('%H:%M') %}
+              {% if entry.value <= max_price and hour not in profitable_hours and ns.counter < hours_needed %}
+                {% set ns.economical_hours = ns.economical_hours + [hour] %}
+                {% set ns.counter = ns.counter + 1 %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.economical_hours }}
+          {% else %}
+            []
+          {% endif %}
+
+  - binary_sensor:
+      # Complex forced discharge timer with battery level and solar power check
+      - name: forced_discharge_timer
+        unique_id: forced_discharge_timer
+        state: >-
+          {% set current_time = now() %}
+          {% set current_date = current_time.date() %}
+          {% set current_hour = current_time.hour %}
+          {% set min_forced_sell_price = states('input_number.min_forced_sell_price')|float(0.3) %}
+          {% set forced_discharge_hours = states('input_number.forced_discharge_hours')|int(2) %}
+          {% set battery_capacity = states('sensor.battery_capacity')|float(0) %}
+          {% set battery_level = states('sensor.battery_level')|float(0) %}
+          {% set min_battery_level = states('input_number.min_battery_discharge_level')|float(25) %}
+          {% set solar_power = states('sensor.power_production_now')|float(0) %}
+          {% set min_solar_threshold = states('input_number.min_solar_power_threshold')|float(500) %}
+          {% set today_data = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'raw_today') %}
+          {% if battery_capacity > 35 and (battery_level > min_battery_level or solar_power >= min_solar_threshold) and today_data %}
+            {% set sorted_data = today_data|sort(attribute='value', reverse=true) %}
+            {% set ns = namespace(found=false, counter=0) %}
+            {% for entry in sorted_data %}
+              {% if entry.value >= min_forced_sell_price and ns.counter < forced_discharge_hours %}
+                {% set entry_date = entry.start.date() %}
+                {% set entry_hour = entry.start.hour %}
+                {% set ns.counter = ns.counter + 1 %}
+                {% if entry_date == current_date and entry_hour == current_hour %}
+                  {% set ns.found = true %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.found }}
+          {% else %}
+            {{ false }}
+          {% endif %}
+
+      # Low price mode detector
+      - name: low_price_mode
+        unique_id: low_price_mode
+        state: >-
+          {% set price = states('sensor.nordpool_kwh_ee_eur_3_10_022')|float(999) %}
+          {% set min_price = states('input_number.min_export_price')|float(0.0125) %}
+          {{ price <= min_price }}
+
+      # Export profitable mode detector
+      - name: export_profitable_mode
+        unique_id: export_profitable_mode
+        state: >-
+          {% set current_price = states('sensor.nordpool_kwh_ee_eur_3_10_022')|float(0) %}
+          {% set min_export_price = states('input_number.min_export_price')|float(0.0125) %}
+          {{ current_price > min_export_price }}
+            
+      # Cheapest hours for charging timer
+      - name: cheapest_hours_for_charging_timer
+        unique_id: cheapest_hours_for_charging_timer
+        state: >-
+          {% set hours_needed = states('input_number.max_battery_f_charging_time')|int(1) %}
+          {% set max_price = states('input_number.max_price_force_charge')|float(0) %}
+          {% set nordpool_data = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'raw_today') %}
+          {% set current_hour = now().hour %}
+          {% if nordpool_data %}
+            {% set sorted_data = nordpool_data|sort(attribute='value') %}
+            {% set ns = namespace(cheapest_hours=[]) %}
+            {% for entry in sorted_data %}
+              {% if entry.value <= max_price and ns.cheapest_hours|length < hours_needed %}
+                {% set ns.cheapest_hours = ns.cheapest_hours + [entry.start.hour] %}
+              {% endif %}
+            {% endfor %}
+            {{ current_hour in ns.cheapest_hours }}
+          {% else %}
+            {{ false }}
+          {% endif %}
+            
+      # Battery below 15% detector
+      - name: battery_below_15
+        unique_id: battery_below_15
+        state: >-
+          {{ states('sensor.battery_level')|float(100) < 15 }}
+          
+      # Solar power availability detector
+      - name: solar_power_available
+        unique_id: solar_power_available
+        state: >-
+          {% set solar_power = states('sensor.power_production_now')|float(0) %}
+          {% set min_solar_threshold = states('input_number.min_solar_power_threshold')|float(500) %}
+          {{ solar_power >= min_solar_threshold }}
+
+      # Nord Pool price above minimum detector
+      - name: nordpool_price_above_min
+        unique_id: nordpool_price_above_min
+        state: >-
+          {% set current_price = state_attr('sensor.nordpool_kwh_ee_eur_3_10_022', 'value')|float(0) %}
+          {% set min_price = states('input_number.min_forced_sell_price')|float(0.3) %}
+          {{ current_price > min_price }}
+
+# Text-to-speech
+tts:
+  - platform: google_translate
+
+# Automations
+automation:
+  # Battery charging management during cheapest hours
+  - alias: Forced Battery Charging Management
+    id: forced_battery_charging_management
+    description: "Manages forced battery charging during cheapest hours based on battery level."
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.cheapest_hours_for_charging_timer
+    action:
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.cheapest_hours_for_charging_timer
+                state: 'on'
+            sequence:
+              - service: script.sg_set_forced_charge_battery_mode
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.cheapest_hours_for_charging_timer
+                state: 'off'
+            sequence:
+              - service: script.sg_set_self_consumption_mode
+
+  # Battery discharge management during high price hours
+  - alias: Forced Battery Discharge Management
+    id: forced_battery_discharge_management
+    description: "Forced discharge of battery during specified high-price hours with minimum battery level protection and solar override."
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.forced_discharge_timer
+      - platform: numeric_state
+        entity_id: sensor.battery_level
+        below: input_number.min_battery_discharge_level
+      - platform: state
+        entity_id: binary_sensor.solar_power_available
+    action:
+      - choose:
+          - conditions:
+              - condition: state
+                entity_id: binary_sensor.forced_discharge_timer
+                state: 'on'
+              - condition: or
+                conditions:
+                  - condition: numeric_state
+                    entity_id: sensor.battery_level
+                    above: input_number.min_battery_discharge_level
+                  - condition: state
+                    entity_id: binary_sensor.solar_power_available
+                    state: 'on'
+            sequence:
+              - service: script.sg_set_forced_discharge_battery_mode
+              - service: notify.notify
+                data:
+                  title: "Battery Discharge Started"
+                  message: >-
+                    Forced discharge activated. Battery: {{ states('sensor.battery_level')|float(0) }}%, 
+                    Solar: {{ states('sensor.power_production_now')|float(0) }}W, 
+                    Price: {{ states('sensor.nordpool_kwh_ee_eur_3_10_022')|float(0) }} EUR/kWh
+                    {% if states('sensor.power_production_now')|float(0) >= states('input_number.min_solar_power_threshold')|float(500) %}
+                    (Solar override active)
+                    {% endif %}
+          - conditions:
+              - condition: or
+                conditions:
+                  - condition: state
+                    entity_id: binary_sensor.forced_discharge_timer
+                    state: 'off'
+                  - condition: and
+                    conditions:
+                      - condition: numeric_state
+                        entity_id: sensor.battery_level
+                        below: input_number.min_battery_discharge_level
+                      - condition: state
+                        entity_id: binary_sensor.solar_power_available
+                        state: 'off'
+            sequence:
+              - service: script.sg_set_self_consumption_mode
+              - service: notify.notify
+                data:
+                  title: "Battery Discharge Stopped"
+                  message: >-
+                    {% set battery_level = states('sensor.battery_level')|float(0) %}
+                    {% set min_level = states('input_number.min_battery_discharge_level')|float(25) %}
+                    {% set solar_power = states('sensor.power_production_now')|float(0) %}
+                    {% set min_solar = states('input_number.min_solar_power_threshold')|float(500) %}
+                    {% if battery_level < min_level and solar_power < min_solar %}
+                      Forced discharge stopped - Battery level ({{ battery_level }}%) below minimum ({{ min_level }}%) and insufficient solar ({{ solar_power }}W < {{ min_solar }}W)
+                    {% elif not is_state('binary_sensor.forced_discharge_timer', 'on') %}
+                      Forced discharge stopped - High price period ended
+                    {% else %}
+                      Forced discharge stopped - Conditions no longer met
+                    {% endif %}
+
+  # Export limiter management based on price conditions
+  - alias: Export Limiter Management
+    id: export_limiter_management
+    description: "Manages export power limit based on energy prices to prevent selling at loss"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.low_price_mode
+      - platform: state
+        entity_id: binary_sensor.export_profitable_mode
+    condition:
+      - condition: template
+        value_template: "{{ trigger.from_state is not none }}"
+    action:
+      - service: input_number.set_value
+        target:
+          entity_id: input_number.set_sg_export_power_limit
+        data:
+          value: >-
+            {% if is_state('binary_sensor.low_price_mode', 'on') %}
+              0
+            {% elif is_state('binary_sensor.export_profitable_mode', 'on') %}
+              10000
+            {% else %}
+              0
+            {% endif %}
+      - service: notify.notify
+        data:
+          title: "Export Limiter Update"
+          message: >-
+            {% set price = states('sensor.nordpool_kwh_ee_eur_3_10_022') %}
+            {% set min_export = states('input_number.min_export_price') %}
+            {% set limit = states('input_number.set_sg_export_power_limit') %}
+            {% if is_state('binary_sensor.low_price_mode', 'on') %}
+              Export DISABLED (0W) - Price too low ({{ price }} ≤ {{ min_export }} EUR/kWh)
+            {% elif is_state('binary_sensor.export_profitable_mode', 'on') %}
+              Export ENABLED ({{ limit }}W) - Profitable price ({{ price }} > {{ min_export }} EUR/kWh)
+            {% else %}
+              Export DISABLED (0W) - Price at minimum threshold ({{ price }} EUR/kWh)
+            {% endif %}
+
+  # Midnight safety reset - prevents inverter from staying in Forced Mode overnight
+  - alias: Midnight Safety Reset
+    id: midnight_safety_reset
+    description: "Reset inverter to Self-consumption at midnight if no active charge/discharge slots"
+    trigger:
+      - platform: time
+        at: "00:00:00"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.forced_discharge_timer
+        state: 'off'
+      - condition: state
+        entity_id: binary_sensor.cheapest_hours_for_charging_timer
+        state: 'off'
+    action:
+      - service: script.sg_set_self_consumption_mode
+      - service: notify.notify
+        data:
+          title: "Midnight Safety Reset"
+          message: "Inverter reset to Self-consumption mode"
+
+# Include other configuration files
+scene: !include scenes.yaml
+
+homeassistant:
+  packages: !include_dir_named integrations

--- a/tests/test_automation_helper.py
+++ b/tests/test_automation_helper.py
@@ -167,6 +167,7 @@ async def test_generate_all_automations_with_control_type():
     assert "Sungrow Scripts" in all_yaml
     assert "Battery Trading: Smart Discharge Control" in all_yaml
     assert "Battery Trading: Smart Charging Control" in all_yaml
+    assert "Battery Trading: Midnight Safety Reset" in all_yaml
 
 
 @pytest.mark.asyncio
@@ -210,3 +211,80 @@ async def test_default_control_type_is_modbus():
     # Should use Modbus control by default
     assert "select.sungrow_ems_mode" in automation_yaml
     assert "number.sungrow_forced_discharging_power" in automation_yaml
+
+
+@pytest.mark.asyncio
+async def test_generate_midnight_reset_modbus():
+    """Test generating midnight safety reset automation for Modbus control."""
+    generator = AutomationScriptGenerator(
+        nordpool_entity="sensor.nordpool_kwh_se3_eur_3_10_025",
+        battery_level_entity="sensor.sungrow_battery_level",
+    )
+
+    automation_yaml = generator.generate_midnight_reset_automation()
+
+    assert "automation:" in automation_yaml
+    assert "Midnight Safety Reset" in automation_yaml
+    assert "battery_trading_midnight_reset" in automation_yaml
+    assert 'at: "00:00:00"' in automation_yaml
+    assert "binary_sensor.battery_energy_trading_forced_discharge" in automation_yaml
+    assert "binary_sensor.battery_energy_trading_cheapest_hours" in automation_yaml
+    assert "select.sungrow_ems_mode" in automation_yaml
+    assert "Self-consumption" in automation_yaml
+    assert "number.sungrow_forced_discharging_power" in automation_yaml
+    assert "number.sungrow_forced_charging_power" in automation_yaml
+    # Should NOT contain Forced Mode - this is a reset automation
+    assert "Forced Mode" not in automation_yaml
+
+
+@pytest.mark.asyncio
+async def test_generate_midnight_reset_scripts():
+    """Test generating midnight safety reset automation for script-based control."""
+    options = {
+        CONF_INVERTER_CONTROL_TYPE: INVERTER_CONTROL_SUNGROW_SCRIPTS,
+        CONF_CUSTOM_DISCHARGE_SERVICE: "script.turn_on",
+        CONF_CUSTOM_DISCHARGE_ENTITY: DEFAULT_SUNGROW_SCRIPT_DISCHARGE,
+        CONF_CUSTOM_CHARGE_SERVICE: "script.turn_on",
+        CONF_CUSTOM_CHARGE_ENTITY: DEFAULT_SUNGROW_SCRIPT_CHARGE,
+        CONF_CUSTOM_NORMAL_SERVICE: "script.turn_on",
+        CONF_CUSTOM_NORMAL_ENTITY: DEFAULT_SUNGROW_SCRIPT_NORMAL,
+    }
+    generator = AutomationScriptGenerator(
+        nordpool_entity="sensor.nordpool_kwh_se3_eur_3_10_025",
+        battery_level_entity="sensor.sungrow_battery_level",
+        options=options,
+    )
+
+    automation_yaml = generator.generate_midnight_reset_automation()
+
+    assert "Midnight Safety Reset" in automation_yaml
+    assert 'at: "00:00:00"' in automation_yaml
+    assert "script.turn_on" in automation_yaml
+    assert DEFAULT_SUNGROW_SCRIPT_NORMAL in automation_yaml
+    # Should NOT contain Modbus entities
+    assert "select.sungrow_ems_mode" not in automation_yaml
+
+
+@pytest.mark.asyncio
+async def test_generate_midnight_reset_custom():
+    """Test generating midnight safety reset automation for custom control."""
+    options = {
+        CONF_INVERTER_CONTROL_TYPE: INVERTER_CONTROL_CUSTOM,
+        CONF_CUSTOM_DISCHARGE_SERVICE: "homeassistant.turn_on",
+        CONF_CUSTOM_DISCHARGE_ENTITY: "input_boolean.my_discharge_mode",
+        CONF_CUSTOM_CHARGE_SERVICE: "homeassistant.turn_on",
+        CONF_CUSTOM_CHARGE_ENTITY: "input_boolean.my_charge_mode",
+        CONF_CUSTOM_NORMAL_SERVICE: "homeassistant.turn_off",
+        CONF_CUSTOM_NORMAL_ENTITY: "input_boolean.my_discharge_mode",
+    }
+    generator = AutomationScriptGenerator(
+        nordpool_entity="sensor.nordpool_kwh_se3_eur_3_10_025",
+        battery_level_entity="sensor.custom_battery_level",
+        options=options,
+    )
+
+    automation_yaml = generator.generate_midnight_reset_automation()
+
+    assert "Midnight Safety Reset" in automation_yaml
+    assert "homeassistant.turn_off" in automation_yaml
+    assert "input_boolean.my_discharge_mode" in automation_yaml

--- a/tests/test_automation_installer.py
+++ b/tests/test_automation_installer.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.battery_energy_trading.automation_installer import (
     CHARGING_AUTOMATION_ID,
     DISCHARGE_AUTOMATION_ID,
+    MIDNIGHT_RESET_AUTOMATION_ID,
     AutomationInstaller,
 )
 from custom_components.battery_energy_trading.const import (
@@ -213,9 +214,10 @@ class TestAutomationStatus:
         status = installer.get_automation_status()
 
         assert len(status["installed"]) == 0
-        assert len(status["missing"]) == 2
+        assert len(status["missing"]) == 3
         assert DISCHARGE_AUTOMATION_ID in status["missing"]
         assert CHARGING_AUTOMATION_ID in status["missing"]
+        assert MIDNIGHT_RESET_AUTOMATION_ID in status["missing"]
 
     def test_get_automation_status_one_installed(self, mock_hass, mock_config_entry_modbus):
         """Test status when one automation is installed."""
@@ -234,9 +236,10 @@ class TestAutomationStatus:
         status = installer.get_automation_status()
 
         assert len(status["installed"]) == 1
-        assert len(status["missing"]) == 1
+        assert len(status["missing"]) == 2
         assert status["installed"][0]["id"] == DISCHARGE_AUTOMATION_ID
         assert CHARGING_AUTOMATION_ID in status["missing"]
+        assert MIDNIGHT_RESET_AUTOMATION_ID in status["missing"]
 
     def test_get_automation_status_all_installed(self, mock_hass, mock_config_entry_modbus):
         """Test status when all automations are installed."""
@@ -252,7 +255,7 @@ class TestAutomationStatus:
         installer = AutomationInstaller(mock_hass, mock_config_entry_modbus)
         status = installer.get_automation_status()
 
-        assert len(status["installed"]) == 2
+        assert len(status["installed"]) == 3
         assert len(status["missing"]) == 0
 
 
@@ -283,9 +286,10 @@ class TestInstallAutomations:
 
         created_ids = await installer.async_install_automations()
 
-        # Should return both automation IDs
+        # Should return all three automation IDs
         assert DISCHARGE_AUTOMATION_ID in created_ids
         assert CHARGING_AUTOMATION_ID in created_ids
+        assert MIDNIGHT_RESET_AUTOMATION_ID in created_ids
 
 
 class TestUninstallAutomations:
@@ -328,7 +332,73 @@ class TestUninstallAutomations:
 
             removed_ids = await installer.async_uninstall_automations()
 
-        # Should have attempted to remove both automations
-        assert len(removed_ids) == 2
+        # Should have attempted to remove all three automations
+        assert len(removed_ids) == 3
         assert DISCHARGE_AUTOMATION_ID in removed_ids
         assert CHARGING_AUTOMATION_ID in removed_ids
+        assert MIDNIGHT_RESET_AUTOMATION_ID in removed_ids
+
+
+class TestMidnightResetAutomationConfig:
+    """Tests for midnight safety reset automation configuration."""
+
+    def test_modbus_midnight_reset_config(self, mock_hass, mock_config_entry_modbus):
+        """Test midnight reset config for Modbus control type."""
+        installer = AutomationInstaller(mock_hass, mock_config_entry_modbus)
+        config = installer._get_midnight_reset_automation_config()
+
+        assert config["id"] == MIDNIGHT_RESET_AUTOMATION_ID
+        assert config["alias"] == "Battery Trading: Midnight Safety Reset"
+        assert "Auto-installed" in config["description"]
+
+        # Trigger at midnight
+        assert len(config["trigger"]) == 1
+        assert config["trigger"][0]["platform"] == "time"
+        assert config["trigger"][0]["at"] == "00:00:00"
+
+        # Conditions: both binary sensors must be off
+        assert len(config["condition"]) == 2
+        assert config["condition"][0]["entity_id"] == (
+            "binary_sensor.battery_energy_trading_forced_discharge"
+        )
+        assert config["condition"][0]["state"] == "off"
+        assert config["condition"][1]["entity_id"] == (
+            "binary_sensor.battery_energy_trading_cheapest_hours"
+        )
+        assert config["condition"][1]["state"] == "off"
+
+        # Actions: reset to self-consumption and zero power
+        assert len(config["action"]) == 3
+        assert config["action"][0]["service"] == "select.select_option"
+        assert config["action"][0]["target"]["entity_id"] == DEFAULT_SUNGROW_MODBUS_EMS_MODE
+        assert config["action"][0]["data"]["option"] == "Self-consumption"
+        assert config["action"][1]["target"]["entity_id"] == DEFAULT_SUNGROW_MODBUS_DISCHARGE_POWER
+        assert config["action"][1]["data"]["value"] == 0
+        assert config["action"][2]["target"]["entity_id"] == DEFAULT_SUNGROW_MODBUS_CHARGE_POWER
+        assert config["action"][2]["data"]["value"] == 0
+
+    def test_scripts_midnight_reset_config(self, mock_hass, mock_config_entry_scripts):
+        """Test midnight reset config for script control type."""
+        installer = AutomationInstaller(mock_hass, mock_config_entry_scripts)
+        config = installer._get_midnight_reset_automation_config()
+
+        assert config["id"] == MIDNIGHT_RESET_AUTOMATION_ID
+
+        # Should call normal mode script
+        assert len(config["action"]) == 1
+        assert config["action"][0]["service"] == "script.turn_on"
+        assert config["action"][0]["target"]["entity_id"] == (
+            "script.sg_set_self_consumption_mode"
+        )
+
+    def test_custom_midnight_reset_config(self, mock_hass, mock_config_entry_custom):
+        """Test midnight reset config for custom control type."""
+        installer = AutomationInstaller(mock_hass, mock_config_entry_custom)
+        config = installer._get_midnight_reset_automation_config()
+
+        assert config["id"] == MIDNIGHT_RESET_AUTOMATION_ID
+
+        # Should call custom normal service
+        assert len(config["action"]) == 1
+        assert config["action"][0]["service"] == "homeassistant.turn_off"
+        assert config["action"][0]["target"]["entity_id"] == "input_boolean.discharge_mode"


### PR DESCRIPTION
## Summary
- Adds a midnight (00:00) safety reset automation that forces the inverter back to Self-consumption mode if no charge/discharge slots are active
- Prevents the inverter from getting stuck in Forced Mode overnight due to failed state transitions or external overrides

## Changes
- `automation_helper.py` - Modbus + script templates for midnight reset
- `automation_installer.py` - Install/uninstall/status support for the new automation
- `__init__.py` - Registered `battery_trading_midnight_reset` in AUTOMATION_IDS
- `docs/integrations/sungrow.md` - Manual YAML examples (sections 6 + configuration.yaml example)
- `docs/legacy_configuration.yaml` - Legacy script-based setup
- Tests for all three control types (modbus, scripts, custom)

## Test plan
- [ ] Verify automation templates generate correct YAML for modbus, scripts, and custom control types
- [ ] Verify installer creates/removes the midnight reset alongside discharge and charging automations
- [ ] Verify automation status correctly reports midnight reset as installed/missing
- [ ] Confirm automation triggers at 00:00 and only resets when no active slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)